### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can use [CocoaPods](http://cocoapods.org/) to install `EZAlertController` by
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'EZAlertController', '3.0'
+pod 'EZAlertController', '0.3'
 ```
 
 ### Install Manually


### PR DESCRIPTION
pod 'EZAlertController', '0.3'
